### PR TITLE
Fixed rotation issues by upgrading to iOS 8

### DIFF
--- a/Classes/YIPopupTextView.h
+++ b/Classes/YIPopupTextView.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSInteger, YIPopupTextViewButtonStyle) {
 @property (nonatomic, strong) UIColor* outerBackgroundColor;    // default = black opaque
 
 @property (nonatomic, assign) BOOL caretShiftGestureEnabled;    // default = NO
-
+@property (nonatomic, assign) NSUInteger maxCount;
 @property (nonatomic) CGFloat topUIBarMargin;       // set statusBar+navBar height for iOS7 fullscreen size manually
 @property (nonatomic) CGFloat bottomUIBarMargin;    // set tabBar+toolbar height for iOS7 fullscreen size manually
 

--- a/Classes/YIPopupTextView.m
+++ b/Classes/YIPopupTextView.m
@@ -342,6 +342,16 @@ typedef enum {
 
 #pragma mark Accessors
 
+- (NSInteger)maxCount {
+    return _maxCount;
+}
+
+- (void)setMaxCount:(NSInteger)maxCount {
+     _maxCount = maxCount;
+    [self updateCount];
+}
+
+
 - (UIColor *)outerBackgroundColor
 {
     return _backgroundView.backgroundColor;
@@ -619,7 +629,8 @@ typedef enum {
 - (void)updateCount
 {
     NSUInteger textCount = [self.text length];
-    _countLabel.text = [NSString stringWithFormat:@"%lu", (unsigned long)_maxCount-textCount];
+    NSInteger deltaCount = _maxCount - textCount;
+    _countLabel.text = [NSString stringWithFormat:@"%d",deltaCount];
     
     if (_maxCount > 0 && textCount > _maxCount) {
         _acceptButton.enabled = NO;

--- a/Classes/YIPopupTextView.m
+++ b/Classes/YIPopupTextView.m
@@ -238,6 +238,7 @@ typedef enum {
         self.autocapitalizationType = UITextAutocapitalizationTypeNone;
         self.layer.cornerRadius = 10;
         self.backgroundColor = [UIColor whiteColor];
+        self.contentMode =  UIViewContentModeRedraw;
         [_popupView addSubview:self];
         
         if (maxCount > 0) {
@@ -346,7 +347,7 @@ typedef enum {
     return _maxCount;
 }
 
-- (void)setMaxCount:(NSInteger)maxCount {
+- (void)setMaxCount:(NSUInteger)maxCount {
      _maxCount = maxCount;
     [self updateCount];
 }
@@ -545,18 +546,15 @@ typedef enum {
     
     CGFloat topMargin = _topUIBarMargin;
     CGFloat bottomMargin = _bottomUIBarMargin;
-    
     CGFloat popupViewHeight = 0;
     
-#if defined(__IPHONE_7_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_7_0
-    
-    // automatically adjusts top/bottomUIBarMargin for iOS7 fullscreen size
+
     if (_viewController) {
         UINavigationBar* navBar = _viewController.navigationController.navigationBar;
         UIToolbar* toolbar = _viewController.navigationController.toolbar;
         UITabBar* tabBar = _viewController.tabBarController.tabBar;
         
-        CGFloat statusBarHeight = (IS_PORTRAIT ? [UIApplication sharedApplication].statusBarFrame.size.height : [UIApplication sharedApplication].statusBarFrame.size.width);
+        CGFloat statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
         CGFloat navBarHeight = (navBar && !navBar.hidden ? navBar.bounds.size.height : 0);
         CGFloat toolbarHeight = (toolbar && !toolbar.hidden ? toolbar.bounds.size.height : 0);
         CGFloat tabBarHeight = (tabBar && !tabBar.hidden ? tabBar.bounds.size.height : 0);
@@ -569,7 +567,7 @@ typedef enum {
         }
     }
     
-#endif
+
 
     if (notification) {
         NSDictionary* userInfo = [notification userInfo];
@@ -580,9 +578,9 @@ typedef enum {
         }
         
         CGPoint bgOrigin = [self.window convertPoint:CGPointZero fromView:_backgroundView];
-        
         UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
-        
+
+
         switch (orientation) {
             case UIInterfaceOrientationPortrait:
                 popupViewHeight = keyboardRect.origin.y - bgOrigin.y - topMargin;
@@ -592,22 +590,21 @@ typedef enum {
                 break;
             case UIInterfaceOrientationLandscapeLeft:
                 // keyboard at portrait-right
-                popupViewHeight = keyboardRect.origin.x - bgOrigin.x - topMargin;
+                popupViewHeight = keyboardRect.origin.y - bgOrigin.y - topMargin;
                 break;
             case UIInterfaceOrientationLandscapeRight:
                 // keyboard at portrait-left
-                popupViewHeight = bgOrigin.x - keyboardRect.origin.x - keyboardRect.size.width - topMargin;
+                popupViewHeight = keyboardRect.origin.y -  bgOrigin.y - topMargin;
                 break;
             default:
                 break;
         }
-    }
-    else {
+    } else {
         popupViewHeight = _backgroundView.bounds.size.height;
     }
     
     popupViewHeight = MIN(popupViewHeight, _backgroundView.bounds.size.height-topMargin-bottomMargin);
-    
+
     CGRect frame = _backgroundView.bounds;
     frame.origin.y = topMargin;
     frame.size.height = popupViewHeight;

--- a/Classes/YIPopupTextView.m
+++ b/Classes/YIPopupTextView.m
@@ -342,7 +342,7 @@ typedef enum {
 
 #pragma mark Accessors
 
-- (NSInteger)maxCount {
+- (NSUInteger)maxCount {
     return _maxCount;
 }
 

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -1,3 +1,3 @@
-platform :ios, '5.0'
+platform :ios, '8.0'
 
 pod 'YIPopupTextView', :path => '../'

--- a/Demo/YIPopupTextViewDemo.xcodeproj/project.pbxproj
+++ b/Demo/YIPopupTextViewDemo.xcodeproj/project.pbxproj
@@ -21,8 +21,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0170871C34BF449B965C8351 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = SOURCE_ROOT; };
 		1F0D474A1871C507003381F2 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		2FA1681FC12D2621EC3EDBA1 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		48C34CA314D920D40012AB8B /* YIPopupTextViewDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YIPopupTextViewDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		48C34CA714D920D40012AB8B /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		48C34CA914D920D40012AB8B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -38,6 +38,7 @@
 		48C34CBD14D920D50012AB8B /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		48C34CD014D923DE0012AB8B /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		A3F71381404F4BE99FA0B57B /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC6D7C6A4273BDFEBABA5F39 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,13 +57,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		35AC4E1C30CBEB58026AE9BB /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				2FA1681FC12D2621EC3EDBA1 /* Pods.debug.xcconfig */,
+				EC6D7C6A4273BDFEBABA5F39 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		48C34C9814D920D40012AB8B = {
 			isa = PBXGroup;
 			children = (
 				48C34CAD14D920D40012AB8B /* YIPopupTextViewDemo */,
 				48C34CA614D920D40012AB8B /* Frameworks */,
 				48C34CA414D920D40012AB8B /* Products */,
-				0170871C34BF449B965C8351 /* Pods.xcconfig */,
+				35AC4E1C30CBEB58026AE9BB /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -199,7 +209,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -283,12 +293,12 @@
 		};
 		48C34CC214D920D50012AB8B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0170871C34BF449B965C8351 /* Pods.xcconfig */;
+			baseConfigurationReference = 2FA1681FC12D2621EC3EDBA1 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "YIPopupTextViewDemo/YIPopupTextViewDemo-Prefix.pch";
 				INFOPLIST_FILE = "YIPopupTextViewDemo/YIPopupTextViewDemo-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
@@ -297,12 +307,12 @@
 		};
 		48C34CC314D920D50012AB8B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0170871C34BF449B965C8351 /* Pods.xcconfig */;
+			baseConfigurationReference = EC6D7C6A4273BDFEBABA5F39 /* Pods.release.xcconfig */;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "YIPopupTextViewDemo/YIPopupTextViewDemo-Prefix.pch";
 				INFOPLIST_FILE = "YIPopupTextViewDemo/YIPopupTextViewDemo-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;

--- a/YIPopupTextView.podspec
+++ b/YIPopupTextView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'YIPopupTextView'
-  s.version  = '1.1.2'
+  s.version  = '1.1.3'
   s.license  = { :type => 'Beerware', :text => 'If we meet some day, and you think this stuff is worth it, you can buy me a beer in return.' }
   s.homepage = 'https://github.com/inamiy/YIPopupTextView'
   s.author   = { 'Yasuhiro Inami' => 'inamiy@gmail.com' }
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/inamiy/YIPopupTextView.git', :tag => "#{s.version}" }
   s.source_files = 'Classes/*.{h,m}'
   s.requires_arc = true
-  s.platform = :ios, '5.0'
+  s.platform = :ios, '8.0'
 
   s.requires_arc = true
 end

--- a/YIPopupTextView.podspec
+++ b/YIPopupTextView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'YIPopupTextView'
-  s.version  = '1.1.1'
+  s.version  = '1.1.2'
   s.license  = { :type => 'Beerware', :text => 'If we meet some day, and you think this stuff is worth it, you can buy me a beer in return.' }
   s.homepage = 'https://github.com/inamiy/YIPopupTextView'
   s.author   = { 'Yasuhiro Inami' => 'inamiy@gmail.com' }


### PR DESCRIPTION
Keyboard only works in portrait mode because the behavior of view frames is the same between iOS 8 and earlier versions. Presently however, iOS 8 returns the correct height and width regardless of orientation, thus braking any code that might have previously compensated for orientation Thus leaving textview invisible be cause it has a height of zero after various arithmetic. . This fix however is no longer compatible with earlier versions of the SDK, though I doubt an issue as apps must be iOS 8 now anyways for approval so I've read :) Nevertheless, Thanks for the great control!